### PR TITLE
NPM copies .gitignore by default, and so it didn't include lib/

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,20 @@
+# Mac OSX Files
+.DS_Store
+.Trashes
+.Spotlight-V100
+.AppleDouble
+.LSOverride
+
+# Bower & Node Modules
+node_modules
+npm-debug.log
+app/bower_components
+
+# General Files
+.sass-cache
+.hg
+.idea
+.svn
+.cache
+.project
+.tmp


### PR DESCRIPTION
This adds an explicit .npmignore, so it doesn't copy .gitignore
