### PR TITLE
fix interpolation in return value

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -211,7 +211,7 @@ const utils = {
 
   // Get the month name for `d`'s month
   formatMonth(d) {
-    return `MONTHS[d.getMonth()]}`
+    return `${MONTHS[d.getMonth()]}`
   },
 
   // Get 4-digit year from `d`


### PR DESCRIPTION
I just updated to 0.7.0, and it looks like the return value for `utils.formatMonth()` got unintentionally mangled in https://github.com/souporserious/react-midnight/commit/390373deac98cef048a13931b7d964155821b2b1


Before | After
-------|------
<img width="366" alt="screen shot 2018-03-21 at 9 27 29 am" src="https://user-images.githubusercontent.com/5737/37722810-23575782-2cea-11e8-86bb-329251a52fbf.png"> | <img width="343" alt="screen shot 2018-03-21 at 9 23 32 am" src="https://user-images.githubusercontent.com/5737/37722582-9bb89462-2ce9-11e8-87d9-ccf4ee93c691.png">

